### PR TITLE
Fix dangling device references after successful device opening

### DIFF
--- a/fobos/fobos_sdr.c
+++ b/fobos/fobos_sdr.c
@@ -490,6 +490,7 @@ int fobos_sdr_open(struct fobos_sdr_dev_t ** out_dev, uint32_t index)
                     fobos_sdr_set_frequency(dev, 100E6);
                     fobos_sdr_set_samplerate(dev, 10000000.0);
                     fobos_sdr_set_auto_bandwidth(dev, 0.9);
+                    libusb_free_device_list(dev_list, 1);
                     return FOBOS_ERR_OK;
                 }
             }


### PR DESCRIPTION
The same fix as in rigexpert/libfobos#20.

Dangling references to devices prevented further usage of libusb on macOS.
A bunch of the following errors were reported during call to libusb_exit().
> libusb: error [darwin_cleanup_devices] device still referenced at libusb_exit
The next call to libusb_init() failed with the following error
> libusb: error [darwin_first_time_init] libusb_device reference not released on last exit. will not continue

To reproduce the issue, it's enough to add the second call to get_devinfo() function to fobos_sdr_devinfo_main.c.
Without this change, the second enumeration could not find any devices with FobosSDR connected.
